### PR TITLE
동기적으로 이벤트 발행 및 소비처리

### DIFF
--- a/spring-events/.gitignore
+++ b/spring-events/.gitignore
@@ -40,7 +40,7 @@
 # .idea/jarRepositories.xml
 # .idea/modules.xml
 # .idea/*.iml
-# .idea/modules
+.idea/modules
 # *.iml
 # *.ipr
 

--- a/spring-events/build.gradle.kts
+++ b/spring-events/build.gradle.kts
@@ -23,14 +23,23 @@ extra["springCloudGcpVersion"] = "4.7.2"
 extra["springCloudVersion"] = "2022.0.4"
 
 dependencies {
+
+    // spring
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("com.google.cloud:spring-cloud-gcp-starter-pubsub")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
-    runtimeOnly("com.mysql:mysql-connector-j")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+    // mysql
+    runtimeOnly("com.mysql:mysql-connector-j")
+
+    // loggin
+    implementation("io.github.microutils:kotlin-logging-jvm:2.0.11")
+
+    // gcp
+    implementation("com.google.cloud:spring-cloud-gcp-starter-pubsub")
 }
 
 dependencyManagement {

--- a/spring-events/src/main/kotlin/com/example/springevents/sync/CustomSpringEvent.kt
+++ b/spring-events/src/main/kotlin/com/example/springevents/sync/CustomSpringEvent.kt
@@ -1,0 +1,8 @@
+package com.example.springevents.sync
+
+import org.springframework.context.ApplicationEvent
+
+class CustomSpringEvent(
+    source: Any?,
+    val message: String,
+) : ApplicationEvent(source!!)

--- a/spring-events/src/main/kotlin/com/example/springevents/sync/config/SynchronousSpringEventConfig.kt
+++ b/spring-events/src/main/kotlin/com/example/springevents/sync/config/SynchronousSpringEventConfig.kt
@@ -1,0 +1,7 @@
+package com.example.springevents.sync.config
+
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SynchronousSpringEventConfig {
+}

--- a/spring-events/src/main/kotlin/com/example/springevents/sync/listener/SyncCustomSpringEventListener.kt
+++ b/spring-events/src/main/kotlin/com/example/springevents/sync/listener/SyncCustomSpringEventListener.kt
@@ -1,0 +1,24 @@
+package com.example.springevents.sync.listener
+
+import com.example.springevents.sync.CustomSpringEvent
+import mu.KotlinLogging
+import org.springframework.context.ApplicationListener
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+private val logger = KotlinLogging.logger {}
+
+@Component
+class SyncCustomSpringEventListener {
+    @EventListener
+    fun consume(event: CustomSpringEvent) {
+        logger.info("received custom event by @EventHandler. message: ${event.message}")
+    }
+}
+
+@Component
+class SyncCustomSpringEventListenerUnder42 : ApplicationListener<CustomSpringEvent> {
+    override fun onApplicationEvent(event: CustomSpringEvent) {
+        logger.info("received custom event by ApplicationListener. message: ${event.message}")
+    }
+}

--- a/spring-events/src/main/kotlin/com/example/springevents/sync/publisher/SyncCustomSpringEventPublisher.kt
+++ b/spring-events/src/main/kotlin/com/example/springevents/sync/publisher/SyncCustomSpringEventPublisher.kt
@@ -1,0 +1,20 @@
+package com.example.springevents.sync.publisher
+
+import com.example.springevents.sync.CustomSpringEvent
+import mu.KotlinLogging
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+private val logger = KotlinLogging.logger {}
+
+@Component
+class SyncCustomSpringEventPublisher(
+    val applicationEventPublisher: ApplicationEventPublisher,
+) {
+    fun publishCustomEvent(message: String) {
+        logger.info("publishing custom event. message: $message")
+
+        val customSpringEvent = CustomSpringEvent(this, message)
+        applicationEventPublisher.publishEvent(customSpringEvent)
+    }
+}

--- a/spring-events/src/test/kotlin/com/example/springevents/SpringEventsApplicationTests.kt
+++ b/spring-events/src/test/kotlin/com/example/springevents/SpringEventsApplicationTests.kt
@@ -1,7 +1,10 @@
 package com.example.springevents
 
+import com.example.springevents.sync.publisher.SyncCustomSpringEventPublisher
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationEventPublisher
 
 @SpringBootTest
 class SpringEventsApplicationTests {

--- a/spring-events/src/test/kotlin/com/example/springevents/SyncCustomSpringEventPublisherTest.kt
+++ b/spring-events/src/test/kotlin/com/example/springevents/SyncCustomSpringEventPublisherTest.kt
@@ -1,0 +1,34 @@
+package com.example.springevents
+
+import com.example.springevents.sync.listener.SyncCustomSpringEventListener
+import com.example.springevents.sync.listener.SyncCustomSpringEventListenerUnder42
+import com.example.springevents.sync.publisher.SyncCustomSpringEventPublisher
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.ApplicationEventPublisher
+
+@SpringBootTest(
+    classes = [
+        SyncCustomSpringEventPublisher::class,
+        SyncCustomSpringEventListener::class,
+        SyncCustomSpringEventListenerUnder42::class,
+    ],
+)
+class SyncCustomSpringEventPublisherTest {
+
+    @MockBean
+    private lateinit var applicationEventPublisher: ApplicationEventPublisher
+
+    @Autowired
+    private lateinit var publisher: SyncCustomSpringEventPublisher
+
+    @Test
+    fun `event 발행 및 소비 테스트`() {
+        val message = "Test message"
+
+        // 이벤트 발행 함수 호출.
+        publisher.publishCustomEvent(message)
+    }
+}


### PR DESCRIPTION
테스트 결과
---
- 2023-08-29T18:21:32.204+09:00  INFO 86023 --- [    Test worker] c.e.s.s.p.SyncCustomSpringEventPublisher : publishing custom event. message: Test message
- 2023-08-29T18:21:32.208+09:00  INFO 86023 --- [    Test worker] c.e.s.s.l.SyncCustomSpringEventListener  : received custom event by ApplicationListener. message: Test message
- 2023-08-29T18:21:32.209+09:00  INFO 86023 --- [    Test worker] c.e.s.s.l.SyncCustomSpringEventListener  : received custom event by @EventHandler. message: Test message

> 확인한 부분: 이벤트는 하나 발행해도 리스너는 등록된 대로 리슨한다.